### PR TITLE
[Feature] Update faraday version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 .rvmrc
 
 Gemfile.lock
+
+# IDE related files
+.idea

--- a/lib/unbabel-sdk/version.rb
+++ b/lib/unbabel-sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UnbabelSDK
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/unbabel-ruby.gemspec
+++ b/unbabel-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 0.15'
+  spec.add_runtime_dependency 'faraday', '>= 1.0'
   spec.add_runtime_dependency 'json', '~> 2.3'
 
   spec.add_development_dependency 'pry', '~> 0.11'


### PR DESCRIPTION
This is required to be able to use the latest sentry 4.0 gem in the CMS.

This is part of the task: https://cuseum.atlassian.net/browse/CMS-1076